### PR TITLE
Automatic Linux and Mac Builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ before_install:
         OSNAME="MacOSX";
         brew update;
         brew unlink boost cmake;
-        #brew install llvm36 --with-clang;
         brew install cmake boost boost-python libconfig;
       elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         OSNAME="Linux";

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,20 @@ sudo: required
 
 compiler: clang
 
+os:
+    #- linux
+    - osx
+
+env:
+    - PYVERSION=2.7
+    - PYVERSION=3.4
+
+
+# Don't try py2 build on MacOSX
 matrix:
-  include:
-    - env: PYVERSION=2.7
-      os: linux
-    - env: PYVERSION=3.4
-      os: linux
-    - env: PYVERSION=3.4
-      os: osx
-      osx_image: xcode7.1
+  exclude:
+    - os: osx
+      env: PYVERSION=2.7
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
     - linux
     - osx
 
-osx_image: xcode7.1
+osx_image: xcode7.2b3
 
 env:
     matrix:
@@ -40,7 +40,7 @@ before_install:
         OSNAME="MacOSX";
         brew update;
         brew unlink cmake;
-        brew install cmake boost-python;
+        brew install cmake boost-python libconfig;
       elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
         OSNAME="Linux";
         sudo add-apt-repository ppa:kalakris/cmake -y;
@@ -66,7 +66,6 @@ before_install:
     - DEPS="numpy matplotlib sphinx"
     - conda create -q -n gimli python=$PYVERSION $DEPS
     - source activate gimli
-    - conda install -c http://conda.anaconda.org/numba llvmdev
     - pip install -r doc/requirements.txt # documentation requirements
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@
 
 language: python
 
-os: linux
+os:
+    #- linux
+    - osx
 
 sudo: required
 
@@ -28,23 +30,27 @@ addons:
     - liblapack-dev
     - libsuitesparse-dev
     - libedit-dev
+    - libboost-all-dev
 
 cache:
     directories:
     - thirdParty
 
 before_install:
+    - if [[ "${TRAVIS_OS_NAME}" == 'osx' ]]; then brew install llvm boost boost-python; fi
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+        export PYLIB="/home/travis/miniconda/envs/gimli/lib/libpython2.so"
         else
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        export PYLIB="/home/travis/miniconda/envs/gimli/lib/libpython3.so"
         fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
-    - DEPS="cmake boost numpy matplotlib sphinx"
+    - DEPS="cmake numpy matplotlib sphinx"
     - conda create -q -n gimli python=$TRAVIS_PYTHON_VERSION $DEPS
     - source activate gimli
     - pip install -r doc/requirements.txt # documentation requirements
@@ -64,7 +70,7 @@ install:
     - cd build
     - export CXX="clang++-3.6"
     - export CC="clang-3.6"
-    - cmake ../trunk -DPYTHON_LIBRARY=/home/travis/miniconda/envs/gimli/lib/libpython3.so
+    - cmake ../trunk -DPYTHON_LIBRARY=$PYLIB
     - make -j 4 gimli
     - make pygimli J=4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ addons:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.6
     packages:
-    - llvm-3.6
     - clang-3.6
     - libclang-3.6-dev
+    - llvm-3.6
+    - libllvm-3.6-ocaml-dev
     - libblas-dev
     - liblapack-dev
     - libsuitesparse-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
     - conda create -q -n gimli python=$TRAVIS_PYTHON_VERSION $DEPS
     - source activate gimli
     - pip install -r doc/requirements.txt
+    - conda install -c http://conda.anaconda.org/numba llvmdev
 
 install:
     # Show Infos

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,13 @@ before_install:
 
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
+    - export LD_LIBRARY_PATH="$HOME/miniconda/lib:$LD_LIBRARY_PATH"
+    - export CMAKE_PREFIX_PATH="$HOME/miniconda/"
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - DEPS="numpy matplotlib sphinx"
-    - conda create -q -n gimli python=$PYVERSION $DEPS
-    - source activate gimli
+    - conda install $DEPS
     - conda install -c https://conda.anaconda.org/menpo suitesparse boost metis
     - pip install -r doc/requirements.txt # documentation requirements
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # See build results on http://travis-ci.org/gimli-org/gimli
 # Before commiting changes to this file, check consistency on http://lint.travis-ci.org/
 
-language: cpp
+language: python
 
 os: linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ addons:
     - ppa:kalakris/cmake
     - ppa:boost-latest/ppa
     packages:
+    - build-essential
+    - libcppunit-dev
     - clang-3.6
     - libclang-3.6-dev
     - llvm-3.6
@@ -44,9 +46,6 @@ addons:
     - liblapack-dev
     - libsuitesparse-dev
     - libedit-dev
-    - libboost-system1.55-dev
-    - libboost-thread1.55-dev
-    - libboost-python1.55-dev
 
 cache:
     directories:
@@ -56,10 +55,19 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         OSNAME="MacOSX";
         brew update;
-        brew unlink boost cmake;
-        brew install cmake boost boost-python libconfig;
+        brew unlink cmake;
+        brew install cmake boost-python libconfig;
       elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         OSNAME="Linux";
+        # Travis uses cmake 2.8.7 by default (too old for gimli)
+        sudo add-apt-repository ppa:kalakris/cmake -y
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+        sudo add-apt-repository --yes ppa:boost-latest/ppa
+        sudo apt-get update -qq
+        sudo apt-get install -qq cmake
+
+        # Boost 1.55
+        sudo apt-get install -qq libboost-system1.55-dev libboost-thread1.55-dev libboost-python1.55-dev
       fi
     - if [ "PYVERSION" == "2.7" ]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-$OSNAME-x86_64.sh -O miniconda.sh;
@@ -96,6 +104,10 @@ install:
     - make pygimli J=4
 
 script:
+    # Test gimli
+    - make check
+    - ./bin/gimliUnitTest
+
     # Make sure that interactive matplotlib backends work
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,21 +59,18 @@ before_install:
         brew install cmake boost-python libconfig;
       elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         OSNAME="Linux";
-        # Travis uses cmake 2.8.7 by default (too old for gimli)
-        sudo add-apt-repository ppa:kalakris/cmake -y
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo add-apt-repository --yes ppa:boost-latest/ppa
-        sudo apt-get update -qq
-        sudo apt-get install -qq cmake
-
-        # Boost 1.55
-        sudo apt-get install -qq libboost-system1.55-dev libboost-thread1.55-dev libboost-python1.55-dev
+        sudo add-apt-repository ppa:kalakris/cmake -y;
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
+        sudo add-apt-repository --yes ppa:boost-latest/ppa;
+        sudo apt-get update -qq;
+        sudo apt-get install -qq cmake;
+        sudo apt-get install -qq libboost-system1.55-dev libboost-thread1.55-dev libboost-python1.55-dev;
       fi
     - if [ "PYVERSION" == "2.7" ]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-$OSNAME-x86_64.sh -O miniconda.sh;
-        else
+      else
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-$OSNAME-x86_64.sh -O miniconda.sh;
-        fi
+      fi
 
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ before_install:
         OSNAME="MacOSX";
         brew update;
         brew unlink boost cmake;
-        brew install llvm36 cmake boost boost-python libconfig;
+        brew install llvm36 --with-clang --with-asan;
+        brew install cmake boost boost-python libconfig;
       elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         OSNAME="Linux";
       fi
@@ -69,6 +70,7 @@ before_install:
     - DEPS="cmake numpy matplotlib sphinx"
     - conda create -q -n gimli python=$PYVERSION $DEPS
     - source activate gimli
+    - conda install -c http://conda.anaconda.org/numba llvmdev
     - pip install -r doc/requirements.txt # documentation requirements
 
 install:
@@ -84,7 +86,7 @@ install:
     - mv !(trunk) trunk # necessary because of lib and thirdParty backcopying
     - mkdir build
     - cd build
-    - cmake -DLLVM_CONFIG=$(which ${LLVM_CONFIG}) ../trunk
+    - cmake ../trunk
     - make -j 4 gimli
     - make pygimli J=4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
     - linux
     - osx
 
-osx_image: xcode7.2b3
+osx_image: xcode7.2b2
 
 env:
     matrix:
@@ -45,10 +45,8 @@ before_install:
         OSNAME="Linux";
         sudo add-apt-repository ppa:kalakris/cmake -y;
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
-        sudo add-apt-repository --yes ppa:boost-latest/ppa;
         sudo apt-get update -qq;
         sudo apt-get install -qq cmake;
-        sudo apt-get install -qq libboost-system1.55-dev libboost-thread1.55-dev libboost-python1.55-dev;
         export CXX="clang++-3.6";
         export CC="clang-3.6";
       fi
@@ -66,6 +64,7 @@ before_install:
     - DEPS="numpy matplotlib sphinx"
     - conda create -q -n gimli python=$PYVERSION $DEPS
     - source activate gimli
+    - conda install -c https://conda.anaconda.org/gimli boost
     - pip install -r doc/requirements.txt # documentation requirements
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
     - "2.7"
     - "3.4"
 
-#sudo: false # activates new container-based infrastructure (faster)
+sudo: false # activates new container-based infrastructure (faster)
 
 addons:
   apt:
@@ -23,18 +23,16 @@ addons:
     - llvm-3.6-dev
     - clang-3.6-dev
     - libclang-3.6-dev
+    - libblas-dev
+    - liblapack-dev
+    - libsuitesparse-dev
+    - libedit
 
 cache:
     directories:
     - thirdParty
 
 before_install:
-    # APT-GET (should be reduced or better removed completely)
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libblas-dev liblapack-dev
-    - sudo apt-get install -qq libsuitesparse-dev
-
-    # CONDA
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
         else

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,42 @@
 # Before commiting changes to this file, check consistency on http://lint.travis-ci.org/
 
 language: python
-compiler: clang
-python: 3.4
+
 os: linux
 
-virtualenv:
-    system_site_packages: true
+compiler: clang
+
+python:
+    - "2.7"
+    - "3.4"
+
+#sudo: false # activates new container-based infrastructure (faster)
 
 cache:
-    - pip
     directories:
     - thirdParty
-
+    
 before_install:
-    # We use apt-get to save time, because travis' free build time limit is 50 min.
+    # APT-GET (should be reduced or better removed completely)
     - sudo apt-get update -qq
-    - sudo apt-get install -qq cmake
-    - sudo apt-get install -qq libboost-system-dev libboost-thread-dev libboost-python-dev
-
-    # Main build dependencies
-    - sudo apt-get install -qq build-essential libcppunit-dev
-    - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then sudo apt-get install -qq python-dev python-numpy; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == "3.2" ]]; then sudo apt-get install -qq python3-dev python3-numpy; fi
     - sudo apt-get install -qq libblas-dev liblapack-dev
     - sudo apt-get install -qq libsuitesparse-dev
 
-    # Documentation dependencies
-    - sudo apt-get install -qq doxygen doxygen-latex dvipng python-scipy
-    - sudo apt-get build-dep -qq python-matplotlib python-sphinx
-    - sudo pip install -q -U sphinx numpydoc pybtex sphinxcontrib-programoutput sphinxcontrib-bibtex matplotlib
+    # CONDA
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+        else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - DEPS="cmake boost numpy matplotlib sphinx"
+    - conda create -q -n gimli python=$TRAVIS_PYTHON_VERSION $DEPS
+    - source activate gimli
+    - pip install -r doc/requirements.txt
 
 install:
     # Show Infos
@@ -47,7 +54,7 @@ install:
     - mv !(trunk) trunk # necessary because of lib and thirdParty backcopying
     - mkdir build
     - cd build
-    - cmake ../trunk
+    - cmake ../trunk -DPYTHON_LIBRARY=/home/travis/miniconda/envs/gimli/lib/libpython3.so
     - make -j 4 gimli
     - make pygimli J=4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
 before_install:
     # APT-GET (should be reduced or better removed completely)
     - sudo apt-get update -qq
+    - sudo apt-get install -qq libclang-3.6-dev llvm-3.6-dev
     - sudo apt-get install -qq libblas-dev liblapack-dev
     - sudo apt-get install -qq libsuitesparse-dev
 
@@ -38,8 +39,7 @@ before_install:
     - DEPS="cmake boost numpy matplotlib sphinx"
     - conda create -q -n gimli python=$TRAVIS_PYTHON_VERSION $DEPS
     - source activate gimli
-    - pip install -r doc/requirements.txt
-    - conda install -c http://conda.anaconda.org/numba llvmdev
+    - pip install -r doc/requirements.txt # documentation requirements
 
 install:
     # Show Infos
@@ -71,5 +71,3 @@ script:
     # Test pygimli
     - export PYTHONPATH=$PYTHONPATH:`pwd`/../trunk/python
     - python -c "import pygimli; pygimli.test(onlydoctests=False, htmlreport='build_tests.html')"
-    - chmod +x ../trunk/python/apps/*
-    - make doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,24 @@
 # See build results on http://travis-ci.org/gimli-org/gimli
 # Before commiting changes to this file, check consistency on http://lint.travis-ci.org/
 
-language: python
+language: cpp
 
 os:
-    #- linux
+    - linux
     - osx
 
 sudo: required
 
 compiler: clang
-
-python:
-    - "2.7"
-    - "3.4"
+matrix:
+  include:
+    - env: PYVERSION=2.7
+      os: linux
+    - env: PYVERSION=3.4
+      os: linux
+    - env: PYVERSION=3.4 BEFORE_INSTALL="brew install cmake llvm36 boost boost-python"
+      os: osx
+      osx_image: xcode7.1
 
 addons:
   apt:
@@ -37,13 +42,12 @@ cache:
     - thirdParty
 
 before_install:
-    - if [[ "${TRAVIS_OS_NAME}" == 'osx' ]]; then brew install llvm boost boost-python; fi
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+    - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew --version; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew install llvm36 cmake boost boost-python; fi
+    - if [[ "PYVERSION" == "2.7" ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-        export PYLIB="/home/travis/miniconda/envs/gimli/lib/libpython2.so"
         else
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-        export PYLIB="/home/travis/miniconda/envs/gimli/lib/libpython3.so"
         fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
@@ -70,7 +74,7 @@ install:
     - cd build
     - export CXX="clang++-3.6"
     - export CC="clang-3.6"
-    - cmake ../trunk -DPYTHON_LIBRARY=$PYLIB
+    - cmake ../trunk
     - make -j 4 gimli
     - make pygimli J=4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,11 @@ cache:
     - thirdParty
 
 before_install:
-    #- if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew --version; fi
-    #- if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink boost cmake; fi
-    #- if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install llvm36 cmake boost boost-python; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         OSNAME="MacOSX";
         brew update;
-        brew install llvm36;
+        brew unlink boost cmake;
+        brew install llvm36 cmake boost boost-python;
       elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         OSNAME="Linux";
       fi
@@ -58,6 +56,7 @@ before_install:
         else
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-$OSNAME-x86_64.sh -O miniconda.sh;
         fi
+
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: cpp
 
 os: linux
 
-sudo: required
+sudo: false
 
 compiler: clang
 
@@ -18,11 +18,11 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.6
+    - llvm-toolchain-precise-3.5
     packages:
-    - llvm-3.6-dev
-    - clang-3.6-dev
-    - libclang-3.6-dev
+    - llvm-3.5-dev
+    - clang-3.5-dev
+    - libclang-3.5-dev
     - libblas-dev
     - liblapack-dev
     - libsuitesparse-dev
@@ -61,8 +61,8 @@ install:
     - mv !(trunk) trunk # necessary because of lib and thirdParty backcopying
     - mkdir build
     - cd build
-    - export CXX="clang++-3.6"
-    - export CC="clang-3.6"
+    - export CXX="clang++-3.5"
+    - export CC="clang-3.5"
     - cmake ../trunk -DPYTHON_LIBRARY=/home/travis/miniconda/envs/gimli/lib/libpython3.so
     - make -j 4 gimli
     - make pygimli J=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: required
 compiler: clang
 
 os:
-    #- linux
+    - linux
     - osx
 
 env:
@@ -51,7 +51,7 @@ before_install:
         OSNAME="MacOSX";
         brew update;
         brew unlink boost cmake;
-        brew install llvm36 --with-clang --with-asan;
+        #brew install llvm36 --with-clang;
         brew install cmake boost boost-python libconfig;
       elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         OSNAME="Linux";

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,12 @@ python:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.7
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.7
     packages:
-      - llvm-3.7
-      - clang-3.7
-      - libclang1-3.7
-      - libclang-3.7-dev
+    - llvm-3.7-dev
+    - clang-3.7-dev
+    - libclang-3.7-dev
 
 cache:
     directories:
@@ -54,7 +53,6 @@ before_install:
 install:
     # Show Infos
     - uname -a
-    - clang --version
     - python --version
     - cmake --version
     - python -c "import numpy; print(numpy.__version__)"
@@ -65,6 +63,8 @@ install:
     - mv !(trunk) trunk # necessary because of lib and thirdParty backcopying
     - mkdir build
     - cd build
+    - export CXX="clang++-3.7"
+    - export CC="clang-3.7"
     - cmake ../trunk -DPYTHON_LIBRARY=/home/travis/miniconda/envs/gimli/lib/libpython3.so
     - make -j 4 gimli
     - make pygimli J=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       os: linux
     - env: PYVERSION=3.4
       os: linux
-    - env: PYVERSION=3.4 BEFORE_INSTALL="brew install cmake llvm36 boost boost-python"
+    - env: PYVERSION=3.4
       os: osx
       osx_image: xcode7.1
 
@@ -43,8 +43,9 @@ cache:
 
 before_install:
     - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew --version; fi
-    - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew install llvm36 cmake boost boost-python; fi
-    - if [[ "PYVERSION" == "2.7" ]]; then
+    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink boost; fi
+    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install llvm36 cmake boost boost-python; fi
+    - if [ "PYVERSION" == "2.7" ]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
         else
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: cpp
 
 os: linux
 
-sudo: required
+sudo: false
 
 compiler: clang
 
@@ -18,15 +18,15 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.5
+    - llvm-toolchain-precise-3.6
     packages:
-    - llvm-3.5-dev
-    - clang-3.5-dev
-    - libclang-3.5-dev
+    - llvm-3.6
+    - clang-3.6
+    - libclang-3.6-dev
     - libblas-dev
     - liblapack-dev
     - libsuitesparse-dev
-    - libedit
+    - libedit-dev
 
 cache:
     directories:
@@ -61,8 +61,8 @@ install:
     - mv !(trunk) trunk # necessary because of lib and thirdParty backcopying
     - mkdir build
     - cd build
-    - export CXX="clang++-3.5"
-    - export CC="clang-3.5"
+    - export CXX="clang++-3.6"
+    - export CC="clang-3.6"
     - cmake ../trunk -DPYTHON_LIBRARY=/home/travis/miniconda/envs/gimli/lib/libpython3.so
     - make -j 4 gimli
     - make pygimli J=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - DEPS="cmake numpy matplotlib sphinx"
-    - conda create -q -n gimli python=$TRAVIS_PYTHON_VERSION $DEPS
+    - conda create -q -n gimli python=$PYVERSION $DEPS
     - source activate gimli
     - pip install -r doc/requirements.txt # documentation requirements
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
     - DEPS="numpy matplotlib sphinx"
     - conda create -q -n gimli python=$PYVERSION $DEPS
     - source activate gimli
-    - conda install -c https://conda.anaconda.org/gimli boost
+    - conda install -c https://conda.anaconda.org/menpo suitesparse boost metis
     - pip install -r doc/requirements.txt # documentation requirements
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,24 @@ python:
 
 #sudo: false # activates new container-based infrastructure (faster)
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.7
+    packages:
+      - llvm-3.7
+      - clang-3.7
+      - libclang1-3.7
+      - libclang-3.7-dev
+
 cache:
     directories:
     - thirdParty
-    
+
 before_install:
     # APT-GET (should be reduced or better removed completely)
     - sudo apt-get update -qq
-    - sudo apt-get install -qq libclang-3.6-dev llvm-3.6-dev
     - sudo apt-get install -qq libblas-dev liblapack-dev
     - sudo apt-get install -qq libsuitesparse-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ os:
 osx_image: xcode7.1
 
 env:
-    global:
-    - CXX="clang++-3.6"
-    - CC="clang-3.6"
     matrix:
     - PYVERSION=2.7
     - PYVERSION=3.4
@@ -47,16 +44,16 @@ addons:
     - libsuitesparse-dev
     - libedit-dev
 
-cache:
-    directories:
-    - thirdParty
+#cache:
+    #directories:
+    #- thirdParty
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         OSNAME="MacOSX";
         brew update;
         brew unlink cmake;
-        brew install cmake boost-python libconfig;
+        brew install cmake boost-python;
       elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         OSNAME="Linux";
         sudo add-apt-repository ppa:kalakris/cmake -y;
@@ -65,6 +62,8 @@ before_install:
         sudo apt-get update -qq;
         sudo apt-get install -qq cmake;
         sudo apt-get install -qq libboost-system1.55-dev libboost-thread1.55-dev libboost-python1.55-dev;
+        export CXX="clang++-3.6"
+        export CC="clang-3.6"
       fi
     - if [ "PYVERSION" == "2.7" ]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-$OSNAME-x86_64.sh -O miniconda.sh;
@@ -77,7 +76,7 @@ before_install:
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
-    - DEPS="cmake numpy matplotlib sphinx"
+    - DEPS="numpy matplotlib sphinx"
     - conda create -q -n gimli python=$PYVERSION $DEPS
     - source activate gimli
     - conda install -c http://conda.anaconda.org/numba llvmdev

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: cpp
 
 os: linux
 
-sudo: false
+sudo: required
 
 compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ addons:
     - libllvm-3.6-ocaml-dev
     - libblas-dev
     - liblapack-dev
-    - libsuitesparse-dev
     - libedit-dev
 
 before_install:
@@ -40,7 +39,7 @@ before_install:
         OSNAME="MacOSX";
         brew update;
         brew unlink cmake;
-        brew install cmake boost-python libconfig;
+        brew install cmake llvm boost-python libconfig;
       elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
         OSNAME="Linux";
         sudo add-apt-repository ppa:kalakris/cmake -y;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ os:
     - linux
     - osx
 
+osx_image: xcode7.1
+
 env:
     global:
     - CXX="clang++-3.6"
@@ -31,6 +33,8 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.6
+    - ppa:kalakris/cmake
+    - ppa:boost-latest/ppa
     packages:
     - clang-3.6
     - libclang-3.6-dev
@@ -40,7 +44,9 @@ addons:
     - liblapack-dev
     - libsuitesparse-dev
     - libedit-dev
-    - libboost-all-dev
+    - libboost-system1.55-dev
+    - libboost-thread1.55-dev
+    - libboost-python1.55-dev
 
 cache:
     directories:
@@ -90,10 +96,6 @@ install:
     - make pygimli J=4
 
 script:
-    # Test gimli
-    - make check
-    - ./bin/gimliUnitTest
-
     # Make sure that interactive matplotlib backends work
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,11 @@ env:
     - PYVERSION=2.7
     - PYVERSION=3.4
 
-
 # Don't try py2 build on MacOSX
-matrix:
-  exclude:
-    - os: osx
-      env: PYVERSION=2.7
+#matrix:
+  #exclude:
+    #- os: osx
+      #env: PYVERSION=2.7
 
 addons:
   apt:
@@ -44,13 +43,20 @@ cache:
     - thirdParty
 
 before_install:
-    - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew --version; fi
-    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink boost cmake; fi
-    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install llvm36 cmake boost boost-python; fi
+    #- if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew --version; fi
+    #- if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink boost cmake; fi
+    #- if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install llvm36 cmake boost boost-python; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        OSNAME="MacOSX";
+        brew update;
+        brew install llvm36;
+      elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        OSNAME="Linux";
+      fi
     - if [ "PYVERSION" == "2.7" ]; then
-        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+        wget https://repo.continuum.io/miniconda/Miniconda-latest-$OSNAME-x86_64.sh -O miniconda.sh;
         else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-$OSNAME-x86_64.sh -O miniconda.sh;
         fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,10 @@
 
 language: cpp
 
-os:
-    - linux
-    - osx
-
 sudo: required
 
 compiler: clang
+
 matrix:
   include:
     - env: PYVERSION=2.7
@@ -43,7 +40,7 @@ cache:
 
 before_install:
     - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update; brew --version; fi
-    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink boost; fi
+    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink boost cmake; fi
     - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install llvm36 cmake boost boost-python; fi
     - if [ "PYVERSION" == "2.7" ]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.7
+    - llvm-toolchain-precise-3.6
     packages:
-    - llvm-3.7-dev
-    - clang-3.7-dev
-    - libclang-3.7-dev
+    - llvm-3.6-dev
+    - clang-3.6-dev
+    - libclang-3.6-dev
 
 cache:
     directories:
@@ -63,8 +63,8 @@ install:
     - mv !(trunk) trunk # necessary because of lib and thirdParty backcopying
     - mkdir build
     - cd build
-    - export CXX="clang++-3.7"
-    - export CC="clang-3.7"
+    - export CXX="clang++-3.6"
+    - export CC="clang-3.6"
     - cmake ../trunk -DPYTHON_LIBRARY=/home/travis/miniconda/envs/gimli/lib/libpython3.so
     - make -j 4 gimli
     - make pygimli J=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ language: cpp
 
 os: linux
 
+sudo: required
+
 compiler: clang
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ os:
     - osx
 
 env:
+    global:
+    - CXX="clang++-3.6"
+    - CC="clang-3.6"
+    matrix:
     - PYVERSION=2.7
     - PYVERSION=3.4
 
@@ -47,7 +51,7 @@ before_install:
         OSNAME="MacOSX";
         brew update;
         brew unlink boost cmake;
-        brew install llvm36 cmake boost boost-python;
+        brew install llvm36 cmake boost boost-python libconfig;
       elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         OSNAME="Linux";
       fi
@@ -80,9 +84,7 @@ install:
     - mv !(trunk) trunk # necessary because of lib and thirdParty backcopying
     - mkdir build
     - cd build
-    - export CXX="clang++-3.6"
-    - export CC="clang-3.6"
-    - cmake ../trunk
+    - cmake -DLLVM_CONFIG=$(which ${LLVM_CONFIG}) ../trunk
     - make -j 4 gimli
     - make pygimli J=4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # See build results on http://travis-ci.org/gimli-org/gimli
 # Before commiting changes to this file, check consistency on http://lint.travis-ci.org/
 
-language: python
+language: cpp
 
 os: linux
 
@@ -11,8 +11,6 @@ compiler: clang
 python:
     - "2.7"
     - "3.4"
-
-sudo: false # activates new container-based infrastructure (faster)
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,22 +19,13 @@ env:
     - PYVERSION=2.7
     - PYVERSION=3.4
 
-# Don't try py2 build on MacOSX
-#matrix:
-  #exclude:
-    #- os: osx
-      #env: PYVERSION=2.7
-
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.6
-    - ppa:kalakris/cmake
-    - ppa:boost-latest/ppa
     packages:
     - build-essential
-    - libcppunit-dev
     - clang-3.6
     - libclang-3.6-dev
     - llvm-3.6
@@ -44,17 +35,13 @@ addons:
     - libsuitesparse-dev
     - libedit-dev
 
-#cache:
-    #directories:
-    #- thirdParty
-
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         OSNAME="MacOSX";
         brew update;
         brew unlink cmake;
         brew install cmake boost-python;
-      elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
         OSNAME="Linux";
         sudo add-apt-repository ppa:kalakris/cmake -y;
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
@@ -62,8 +49,8 @@ before_install:
         sudo apt-get update -qq;
         sudo apt-get install -qq cmake;
         sudo apt-get install -qq libboost-system1.55-dev libboost-thread1.55-dev libboost-python1.55-dev;
-        export CXX="clang++-3.6"
-        export CC="clang-3.6"
+        export CXX="clang++-3.6";
+        export CC="clang-3.6";
       fi
     - if [ "PYVERSION" == "2.7" ]; then
         wget https://repo.continuum.io/miniconda/Miniconda-latest-$OSNAME-x86_64.sh -O miniconda.sh;
@@ -100,10 +87,6 @@ install:
     - make pygimli J=4
 
 script:
-    # Test gimli
-    - make check
-    - ./bin/gimliUnitTest
-
     # Make sure that interactive matplotlib backends work
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
This PR reintroduces continuous integration on www.travis-ci.org via the .travis.yml file. It should provide py2 and py3 builds on unix and posix machines. Not fully functional yet, but it's a start.