### PR TITLE
Fix documentation for linux install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Dockerfile used to create a build environment for PyGimli based on the
+# official Debian stretch base image
+
+# build with:
+# docker build -t "gimli/gimli_0.1" .
+
+# after building, start an interactive console in the container with
+# docker run --rm -i -t -u gimli -v "${PWD}":/HOST -w /home/gimli "gimli/gimli_0.1" bash
+# note that this command will mount the present directory to /HOST in the
+# container, e.g., to copy the final build to the host computer
+
+FROM debian:stretch
+
+RUN apt-get update
+
+RUN apt-get install -y wget subversion git cmake mercurial
+RUN apt-get install -y libboost-all-dev libblas-dev liblapack-dev
+RUN apt-get install -y python python-setuptools
+RUN apt-get install -y python-numpy python-matplotlib
+RUN apt-get install -y libedit-dev clang llvm-dev python3-dev
+RUN apt-get install -y python3  python3-numpy python3-matplotlib
+RUN apt-get install -y python3-setuptools
+
+# not required, but used for debugging and testing
+RUN apt-get install -y vim-nox python-pytest python3-pytest
+
+USER root
+# set the root password to "root"
+RUN sh -c "echo root:root |chpasswd"
+
+RUN useradd gimli | chpasswd gimli
+RUN mkdir /home/gimli
+RUN chmod -R 0777 /home/gimli
+RUN chown -R gimli:gimli /home/gimli
+
+USER gimli
+ENV HOME "/home/gimli"
+
+# COPY build_pygimli_py3.5.sh /home/gimli/build_pygimli_py3.5.sh
+RUN echo '#!/bin/bash \n \
+git clone https://github.com/gimli-org/gimli.git \n \
+mkdir build \n \
+cd build \n \
+cmake ../gimli -DPYVERSION=3.5 \n \
+make -j 2 gimli \n \
+make -j 2 apps \n \
+time make -j 2 pygimli \n ' > /home/gimli/build_pygimli_py3.5.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@
 # note that this command will mount the present directory to /HOST in the
 # container, e.g., to copy the final build to the host computer
 
+# the start the build process with
+# bash build_pygimli_py3.5.sh
+
 FROM debian:stretch
 
 RUN apt-get update
@@ -44,4 +47,4 @@ cd build \n \
 cmake ../gimli -DPYVERSION=3.5 \n \
 make -j 2 gimli \n \
 make -j 2 apps \n \
-time make -j 2 pygimli \n ' > /home/gimli/build_pygimli_py3.5.sh 
+make -j 2 pygimli \n ' > /home/gimli/build_pygimli_py3.5.sh

--- a/INSTALL_LINUX.rst
+++ b/INSTALL_LINUX.rst
@@ -214,7 +214,7 @@ Using Docker to build in Debian stretch
 .......................................
 
 If you want to use a Docker container to build (and possibly use) pyGIMLi, you
-can use the Dockerfile found [here](Dockerfile). Please refer to the file for
+can use the Dockerfile found `here<Dockerfile>`. Please refer to the file for
 further instructions.
 
 Example Installation on Ubuntu

--- a/INSTALL_LINUX.rst
+++ b/INSTALL_LINUX.rst
@@ -79,25 +79,24 @@ tab.
 If the installation fails you can try the following instructions for manual
 installation.
 
+Detailed Installation on Debian Stretch
+.......................................
+
 
 Detailed Installation on Ubuntu/Debian systems
 ..............................................
 
-First install some of the necessary stuff. You will need subversion, git and hg
-to retrieve the source files and some things for the tool-chain:
+Install the required packages for the compilation of gimli and pygimli:
 
 .. code-block:: bash
 
-    sudo apt-get install subversion git cmake mercurial
-    sudo apt-get install libboost-all-dev libblas-dev liblapack-dev
-
-If you want to use the pyGIMLi (Python scripts, bindings and apps):
-
-.. code-block:: bash
-
-    sudo apt-get install python-numpy python-matplotlib
-    sudo apt-get install libedit-dev clang-3.6-dev llvm-3.6-dev python3-dev
-
+    sudo apt-get install wget subversion git cmake mercurial \
+        libboost-all-dev libblas-dev liblapack-dev \
+        python python-setuptools \
+        python-numpy python-matplotlib \
+        libedit-dev clang llvm-dev python3-dev \
+        python3  python3-numpy python3-matplotlib \
+        python3-setuptools
 
 Create a directory for your installation, e.g., $HOME/src
 
@@ -134,14 +133,20 @@ Change to the build path
 
     cd build
 
-and configure the build:
+and configure the build for Python 2.7 with:
 
 .. code-block:: bash
 
     cmake ../gimli
 
-If the output complains some missing dependencies, install these and repeat the
-the last step. To build the library just run `make`.
+If you want to compile for Python 3.5, alternatively use:
+
+.. code-block:: bash
+
+    cmake ../gimli -DPYVERSION=3.3
+
+If the output complains about missing dependencies, install these and repeat
+the the last step. To build the library just run `make`.
 
 .. code-block:: bash
 
@@ -153,17 +158,20 @@ To speed up the build process using more CPUs, use the `-j` flag, e.g.:
 
     make -j 8
 
-The libraries will be installed in build/lib and some test applications are
-installed in build/bin. If you want to build the python bindings, call:
+The libraries will be installed in **build/lib** and some test applications are
+installed in build/bin. If you want to build the Python bindings, call:
 
 .. code-block:: bash
 
     make pygimli
 
-You might add J=8 (`make pygimli J=8`) for using 8 jobs in parallel to
-speed up the build. The library _pygimli_.so library will be copied into the
-source path ../gimli/python/pygimli in the subdirectory core. To use the gimli
-installation there have to be set some environment variables:
+You might add J=8 (`make pygimli J=8`) for using 8 jobs in parallel to speed up
+the build (adapt this to the number of real cores of the computer). The library
+_pygimli_.so library will be copied into the source path
+**../gimli/python/pygimli** in the subdirectory core.
+
+To use the gimli installation you need to set some environment variables (this
+example assumes that the **src** directory resides in your home directory):
 
 .. code-block:: bash
 
@@ -177,8 +185,9 @@ If you want to use the C++ command line applications, call
 
     make apps
 
-Compiled binaries will be written to `build/bin`. You can test the pygimli
-build with:
+Compiled binaries will be written to `build/bin`.
+
+You can test the pygimli build with:
 
 .. code-block:: bash
 

--- a/INSTALL_LINUX.rst
+++ b/INSTALL_LINUX.rst
@@ -210,6 +210,13 @@ then you can run the internal test suite with
 
     python -c "import pygimli; pygimli.test()"
 
+Using Docker to build in Debian stretch
+.......................................
+
+If you want to use a Docker container to build (and possibly use) pyGIMLi, you
+can use the Dockerfile found [here](Dockerfile). Please refer to the file for
+further instructions.
+
 Example Installation on Ubuntu
 ..............................
 

--- a/INSTALL_LINUX.rst
+++ b/INSTALL_LINUX.rst
@@ -210,12 +210,12 @@ then you can run the internal test suite with
 
     python -c "import pygimli; pygimli.test()"
 
-Using Docker to build in Debian stretch
-.......................................
+Using Docker to build in Debian stretch (for advanced users only!)
+..................................................................
 
 If you want to use a Docker container to build (and possibly use) pyGIMLi, you
-can use the Dockerfile found `here<Dockerfile>`. Please refer to the file for
-further instructions.
+can use the Dockerfile found in the **scripts/** subdirectory named
+*Dockerfile_DebianStretch*. Please refer to the file for further instructions.
 
 Example Installation on Ubuntu
 ..............................

--- a/INSTALL_LINUX.rst
+++ b/INSTALL_LINUX.rst
@@ -82,11 +82,8 @@ installation.
 Detailed Installation on Debian Stretch
 .......................................
 
-
-Detailed Installation on Ubuntu/Debian systems
-..............................................
-
-Install the required packages for the compilation of gimli and pygimli:
+In order to build pygimli (and gimli) for Python 2.7 and Python 3.5, install
+the required packages:
 
 .. code-block:: bash
 
@@ -143,7 +140,7 @@ If you want to compile for Python 3.5, alternatively use:
 
 .. code-block:: bash
 
-    cmake ../gimli -DPYVERSION=3.3
+    cmake ../gimli -DPYVERSION=3.5
 
 If the output complains about missing dependencies, install these and repeat
 the the last step. To build the library just run `make`.
@@ -187,7 +184,7 @@ If you want to use the C++ command line applications, call
 
 Compiled binaries will be written to `build/bin`.
 
-You can test the pygimli build with:
+You can do a quick test of the pygimli build and installation with:
 
 .. code-block:: bash
 
@@ -199,8 +196,19 @@ You can test your gimli build with:
 
     make check
 
-Note that the test will be very silent if you don't have cppunit installed.
+Note that the test will be very silent if you don't have *cppunit* installed.
 
+If you install pytest with
+
+.. code-block:: bash
+
+    sudo apt-get install python-pytest python3-pytest
+
+then you can run the internal test suite with
+
+.. code-block:: bash
+
+    python -c "import pygimli; pygimli.test()"
 
 Example Installation on Ubuntu
 ..............................

--- a/scripts/Dockerfile_DebianStretch
+++ b/scripts/Dockerfile_DebianStretch
@@ -1,6 +1,8 @@
 # Dockerfile used to create a build environment for PyGimli based on the
 # official Debian stretch base image
 
+# before proceeding, copy to an empty directory and rename to "Dockerfile"
+
 # build with:
 # docker build -t "gimli/gimli_0.1" .
 


### PR DESCRIPTION
This is a request-for-comment pull request, not really a pull request ;-)

The Debian packages required to build pygimli were incomplete and outdated for the current stable Debian (stretch). As you already have an Ubuntu section, I propose to make the Linux Debian section more specific and target Debian stretch (this will reduce misconception regarding the linux distribution where the instructions actually work).

I tested building pygimli using a Docker container based on the official Debians stretch Docker image (debian:stretch). As this could be interesting I also added the Dockerfile to the repository and added a small section in the linux installation instructions. Depending on your preferences I can either delete the Dockerfile, or move it to a location where it belongs. Also, I was not able to add a link to the Dockerfile in the linux installation instructions. Advise would be welcome.