### PR TITLE
Bringing the electrodes back to pytripatch

### DIFF
--- a/python/apps/pytripatch
+++ b/python/apps/pytripatch
@@ -664,7 +664,7 @@ def main(argv):
                     koords = [0, 1]
                 else:
                     d = pg.DataContainer(options.electrodes)
-                    koords = [0, 1]
+                    koords = [0, 2]
                     elPos = d.sensorPositions()
 
                 diam = None


### PR DESCRIPTION
Looks like the problem was that even for 2D coordinates (x,z), the y coordinates was added during parsing. Therefore the koords=[0, 1] always gave the z-value 0. Now it's just koords = [0, 2] so we get the right z coordinates.