### PR TITLE
fix doctests for numpy 1.14.0

### DIFF
--- a/python/pygimli/meshtools/mapping.py
+++ b/python/pygimli/meshtools/mapping.py
@@ -59,7 +59,7 @@ def cellDataToNodeData(mesh, data, style='mean'):
     >>> celldata = np.array([1, 2, 3, 4])
     >>> nodedata = pg.meshtools.cellDataToNodeData(grid, celldata)
     >>> print(nodedata.array())
-    [ 1.   1.5  2.   2.   2.5  3.   3.   3.5  4. ]
+    [1.  1.5 2.  2.  2.5 3.  3.  3.5 4. ]
     """
     if len(data) != mesh.cellCount():
         raise BaseException("Dimension mismatch, expecting cellCount(): " +

--- a/python/pygimli/mplviewer/colorbar.py
+++ b/python/pygimli/mplviewer/colorbar.py
@@ -29,9 +29,9 @@ def autolevel(z, nLevs, logscale=None, zmin=None, zmax=None):
     >>> from pygimli.mplviewer import autolevel
     >>> x = np.linspace(1, 10, 100)
     >>> autolevel(x, 3)
-    array([  1.,   4.,   7.,  10.])
+    array([ 1.,  4.,  7., 10.])
     >>> autolevel(x, 3, logscale=True)
-    array([   0.1,    1. ,   10. ,  100. ])
+    array([  0.1,   1. ,  10. , 100. ])
     """
     locator = None
     if logscale:

--- a/python/pygimli/utils/utils.py
+++ b/python/pygimli/utils/utils.py
@@ -168,18 +168,18 @@ def niceLogspace(vMin, vMax, nDec=10):
     >>> from pygimli.utils import niceLogspace
     >>> v1 = niceLogspace(vMin=0.1, vMax=0.1, nDec=1)
     >>> print(v1)
-    [ 0.1  1. ]
+    [0.1 1. ]
     >>> v1 = niceLogspace(vMin=0.09, vMax=0.11, nDec=1)
     >>> print(v1)
-    [ 0.01  0.1   1.  ]
+    [0.01 0.1  1.  ]
     >>> v1 = niceLogspace(vMin=0.09, vMax=0.11, nDec=10)
     >>> print(len(v1))
     21
     >>> print(v1)
-    [ 0.01        0.01258925  0.01584893  0.01995262  0.02511886  0.03162278
-      0.03981072  0.05011872  0.06309573  0.07943282  0.1         0.12589254
-      0.15848932  0.19952623  0.25118864  0.31622777  0.39810717  0.50118723
-      0.63095734  0.79432823  1.        ]
+    [0.01       0.01258925 0.01584893 0.01995262 0.02511886 0.03162278
+     0.03981072 0.05011872 0.06309573 0.07943282 0.1        0.12589254
+     0.15848932 0.19952623 0.25118864 0.31622777 0.39810717 0.50118723
+     0.63095734 0.79432823 1.        ]
     """
     if vMin > vMax or vMin < 1e-12:
         print("vMin:", vMin, "vMax", vMax)
@@ -347,11 +347,11 @@ def dist(p, c=None):
     >>> p[0] = [0.0, 0.0]
     >>> p[1] = [0.0, 1.0]
     >>> print(dist(p))
-    [ 0.  1.  0.  0.]
+    [0. 1. 0. 0.]
     >>> x = pg.RVector(4, 0)
     >>> y = pg.RVector(4, 1)
     >>> print(dist(np.array([x, y]).T))
-    [ 1.  1.  1.  1.]
+    [1. 1. 1. 1.]
     """
     if c is None:
         c = pg.RVector3(0.0, 0.0, 0.0)
@@ -395,7 +395,7 @@ def cumDist(p):
     >>> p[2] = [0.0, 1.0]
     >>> p[3] = [0.0, 0.0]
     >>> print(cumDist(p))
-    [ 0.  1.  1.  2.]
+    [0. 1. 1. 2.]
     """
     d = np.zeros(len(p))
     d[1:] = np.cumsum(dist(diff(p)))
@@ -622,7 +622,7 @@ def uniqueAndSum(indices, to_sum, return_index=False, verbose=False):
     >>> # you need for example 3 array to find unique node positions in a mesh
     >>> values = np.arange(0.1, 0.7, 0.1)
     >>> print(values)
-    [ 0.1  0.2  0.3  0.4  0.5  0.6]
+    [0.1 0.2 0.3 0.4 0.5 0.6]
     >>> # some values to be summed together (for example attributes of nodes)
     >>> unique_idx, summed_vals = uniqueAndSum(to_sort, values)
     >>> print(unique_idx)
@@ -631,7 +631,7 @@ def uniqueAndSum(indices, to_sum, return_index=False, verbose=False):
      [1 2]
      [2 3]]
     >>> print(summed_vals)
-    [ 0.3  0.3  0.4  1.1]
+    [0.3 0.3 0.4 1.1]
     >>> # [0.1 + 0.2, 03., 0.4, 0.5 + 0.6]
     """
     flag_mult = len(indices) != indices.size


### PR DESCRIPTION
Some doctests fail due to changes in the printing format of numpy,
introduced in version 1.14.0. This PR fixes the tests for numpy == 1.14.0, but breaks them for earlier versions. As such this is not more a request for comments.

For further discussion, see: https://github.com/numpy/numpy/pull/9139

As far as I can see astropy implemented some kind of custom doctest runner to deal with the issue.
