### PR TITLE
Fix complex forward responses for negative geometric factors

### DIFF
--- a/python/pygimli/testing/test_ERTManager_simulate.py
+++ b/python/pygimli/testing/test_ERTManager_simulate.py
@@ -1,0 +1,59 @@
+# *-* coding: utf-8 *-*
+# test some characteristics of ERTManager.simulate:
+# 1) for complex conductivity models the response should not depend on the sign
+#    of the K-factor
+import pybert as pb
+# import pygimli as pg
+import pygimli.meshtools as mt
+import numpy as np
+
+world = mt.createWorld(
+    start=[-50, 0], end=[50, -50], layers=[-1, -5], worldMarker=True)
+
+scheme = pb.DataContainerERT()
+elec_positions = [
+    [-2, 0, 0],
+    [-1, 0, 0],
+    [0, 0, 0],
+    [1, 0, 0],
+    [2, 0, 0],
+]
+for x, y, z in elec_positions:
+    scheme.createSensor((x, y, z))
+
+# Define number of measurements
+scheme.resize(3)
+
+# first two measurements have reversed geometric factor!
+scheme.set('a', [0, 0, 3])
+scheme.set('b', [1, 1, 2])
+scheme.set('m', [3, 2, 1])
+scheme.set('n', [2, 3, 0])
+
+for pos in scheme.sensorPositions():
+    world.createNode(pos)
+    # world.createNode(pos + pg.RVector3(0, -0.1))
+
+mesh = mt.createMesh(world, quality=34)
+
+rhomap = [
+    [1, 99.595 + 8.987j],
+    [2, 99.595 + 8.987j],
+    [3, 59.595 + 8.987j],
+]
+
+ert = pb.ERTManager()
+data = ert.simulate(mesh, res=rhomap, scheme=scheme, verbose=True)
+rhoa = data.get('rhoa').array()
+phia = data.get('phia').array()
+
+# make sure all computed responses are equal, especially the first two, which
+# only differ in the sign of their geometrical factor
+np.testing.assert_allclose(rhoa, rhoa[0])
+np.testing.assert_allclose(phia, phia[0])
+
+# make sure the phases are positive (for positive input)
+assert np.all(phia > 0)
+
+# make sure rhoa is also positive
+assert np.all(rhoa > 0)

--- a/src/bert/dcfemmodelling.cpp
+++ b/src/bert/dcfemmodelling.cpp
@@ -1072,8 +1072,11 @@ RVector DCMultiElectrodeModelling::response(const RVector & model,
         RVector respRe(dMap.data(this->dataContainer(), false, false));
         RVector respIm(dMap.data(this->dataContainer(), false, true));
 
+        respRe *= dataContainer_->get("k");
+        respIm *= dataContainer_->get("k");
+
         CVector resp(toComplex(respRe, respIm));
-        RVector am(abs(resp) * dataContainer_->get("k"));
+        RVector am(abs(resp));
         RVector ph(-angle(resp));
 
         if (verbose_){


### PR DESCRIPTION
For the complex forward response, apply the geometric factor to both real and imaginary part bevore computing phase values. This ensures that we end up with proper phase values. Otherwise a negative K factor would introduce a pi-shift in the phase value (phi_proper = pi - phi_negK).

This commit also includes test case for the issue.