### PR TITLE
Fix requirements

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,6 @@ import sphinx
 
 import pygimli
 from pygimli.utils import boxprint
-from sidebar_gallery import make_gallery
 
 import pkg_resources
 
@@ -31,6 +30,7 @@ import pkg_resources
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('.'))
+from sidebar_gallery import make_gallery
 
 try:
     # from _build.doc.conf_environment import *

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements to test and build the documentation
 # Install via pip: sudo pip install -U -r requirements.txt
-sphinx == 1.6.1
+sphinx >= 1.6.1
 matplotlib>=2.0,<3.0
 numpy>=1.12
 numpydoc>=0.7

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements to test and build the documentation
 # Install via pip: sudo pip install -U -r requirements.txt
-sphinx >= 1.6
-matplotlib>=2.0
+sphinx == 1.6.1
+matplotlib>=2.0,<3.0
 numpy>=1.12
 numpydoc>=0.7
 pytest
@@ -11,3 +11,4 @@ sphinxcontrib-bibtex>=0.3.4
 sphinxcontrib-programoutput>=0.8
 sphinxcontrib-spelling>=2.1
 pillow
+scipy


### PR DESCRIPTION
Fix doc/requirements.txt to a state where the documentation builds in a virtualenv with python 3.5 under Debian stretch.
Also change the position of an import which prevents building the documentation.