### PR TITLE
Add jupyter backend `panel` for 3D pyvista plots in Jupyter Notebook

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -145,8 +145,10 @@ try:
         }
 
     pyvista = pygimli.optImport("pyvista", "building the gallery with 3D visualizations")
+    panel = pygimli.optImport("panel", "Jupyter backend for 3D visualizations on jupyter notebooks")
     if pyvista:
         pyvista.OFF_SCREEN = True
+        pyvista.set_jupyter_backend('panel')
         pyvista.rcParams['window_size'] = np.array([1024, 768]) * 2
         sphinx_gallery_conf["image_scrapers"] = (pyvista.Scraper(), 'matplotlib')
 

--- a/doc/examples/2_seismics/plot_05_refraction_3D.py
+++ b/doc/examples/2_seismics/plot_05_refraction_3D.py
@@ -81,7 +81,7 @@ for receiver in sensors[1:]:
 # Plot final ray paths.
 
 if pyvista:
-    plotter, _ = pg.show(mesh, label=label, alpha=0.1, hold=True)
+    plotter, _ = pg.show(mesh, hold=True, notebook=True)
     drawSensors(plotter, sensors, diam=0.5, color='yellow')
 
     for ray in rays:

--- a/doc/examples/2_seismics/plot_05_refraction_3D.py
+++ b/doc/examples/2_seismics/plot_05_refraction_3D.py
@@ -48,7 +48,7 @@ vel = 300 + -pg.z(mesh.cellCenters()) * 100
 
 if pyvista:
     label = pg.utils.unit("vel")
-    pg.show(mesh, vel, label=label)
+    pg.show(mesh, vel, label=label, notebook=True)
 
 ################################################################################
 # Set-up data container.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,4 +13,5 @@ sphinxcontrib-doxylink
 pillow
 scipy
 bibtexparser
-pyvista==0.24.0
+pyvista==0.33
+panel

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - sphinxcontrib-doxylink
   - scipy
   - bibtexparser
-  - pyvista=0.24
+  - pyvista=0.33
   - meshio
   - tetgen
+  - panel

--- a/pygimli/testing/test_show.py
+++ b/pygimli/testing/test_show.py
@@ -193,10 +193,7 @@ def testShowPV():
     # pg.show(m1)
 
     pg.rc['view3D'] = 'pyvista'
-    #pg.show(m1, notebook=True)
-
-    pg.show(m1)
-
+    pg.show(m1, notebook=True)
 
 def testCoverage():
     grid = pg.createGrid(10,10)

--- a/pygimli/viewer/vistaview.py
+++ b/pygimli/viewer/vistaview.py
@@ -5,44 +5,55 @@ import sys
 import matplotlib.pyplot as plt
 import pygimli as pg
 
-
 PyQt5 = pg.optImport('PyQt5', requiredFor="use pyGIMLi's 3D viewer")
 pyvista = pg.optImport('pyvista', requiredFor="properly visualize 3D data")
+panel = pg.optImport('panel', requiredFor='pyvista jupyter backend')
 
+print(pyvista.__version__)
 if pyvista is None:
     view3Dcallback = 'showMesh3DFallback'
-    pg.rc['view3D'] = 'fallback'
 else:
     view3Dcallback = 'showMesh3DVista'
     vers_users = pyvista.__version__
     vers_userf = float(pyvista.__version__[::-1].replace('.', '', 1)[::-1])
-    vers_needs = '0.23.2'
-    vers_needf = 0.232
+    vers_needs = '0.33.0'
+    vers_needf = 0.330
     if vers_userf < vers_needf:
         pg.warn("Please consider updating PyVista to at least {}".format(
             vers_needs))
-    pg.debug("Using pyvista: {}".format(vers_users))
     from pygimli.viewer.pv import drawModel
 
-# True for Jupyter notebooks and sphinx-builds
-_inlineBackend_ = not pg.viewer.isInteractive()
+if panel is None:
+    pg.warn("Please install panel to plot 3D models in Jupyter Notebooks - conda install panel")
+else:
+    pyvista.set_jupyter_backend('panel')
 
-if PyQt5 is None or _inlineBackend_:
-    _inlineBackend_ = True
+#if pythreejs is None:
+ #   pg.warn("Please install pythreejs")
+#else:
+ #   pyvista.set_jupyter_backend('pythreejs')
+
+#if ipygany is None:
+ #   pg.warn("Please install ipygany")
+#else:
+ #   pyvista.set_jupyter_backend('ipygany')    
+# True for Jupyter notebooks and sphinx-builds
+#_backend = plt.get_backend().lower()
+#inline = "inline" in _backend or _backend == "agg"
+#jupyter_backend='ipygany'
+if PyQt5 is None:
+    inline = True
 else:
     from .pv.show3d import Show3D
     from PyQt5 import Qt
-    _inlineBackend_ = False
+    inline = False
 
 
 def showMesh3D(mesh, data, **kwargs):
     """
     Calling the defined function to show the 3D object.
     """
-    if pg.rc['view3D'] == 'fallback' or pg.rc['view3D'] is None:
-
-        kwargs.pop('gui', None)
-        kwargs['alpha'] = kwargs.pop('opacity', None)
+    if pg.rc['view3D'] == 'fallback':
         return showMesh3DFallback(mesh, data, **kwargs)
 
     return globals()[view3Dcallback](mesh, data, **kwargs)
@@ -58,16 +69,12 @@ def showMesh3DFallback(mesh, data, **kwargs):
 
     if ax is None or not isinstance(ax, Axes3D):
         fig = plt.figure()
-        ax = fig.add_subplot(111, projection='3d',
-                             proj_type='persp'
-                             # proj_type='ortho'
-                             )
+        ax = fig.gca(projection='3d', proj_type='persp')
+        #ax = fig.gca(projection='3d', proj_type='ortho')
 
     if mesh.boundaryCount() > 0:
         x, y, tri, z, dataIndex = pg.viewer.mpl.createTriangles(mesh)
-        kwargs.pop('notebook', False)
-        kwargs.pop('hold', False)
-        ax.plot_trisurf(x, y, tri, z, **kwargs)
+        ax.plot_trisurf(x, y, tri, z)
     else:
         if mesh.nodeCount() < 1e4:
             x = pg.x(mesh.positions())
@@ -104,8 +111,8 @@ def showMesh3DVista(mesh, data=None, **kwargs):
     """
     hold = kwargs.pop('hold', False)
     cmap = kwargs.pop('cmap', 'viridis')
-    notebook = kwargs.pop('notebook', _inlineBackend_)
-    gui = kwargs.pop('gui', False)
+    notebook = kwargs.pop('notebook', inline)
+    gui = kwargs.pop('gui', not notebook)
 
     # add given data from argument
     if gui:
@@ -118,15 +125,8 @@ def showMesh3DVista(mesh, data=None, **kwargs):
 
     else:
         if notebook:
-            pyvista.set_plot_theme('document')
-
-        try:
             plotter = drawModel(None, mesh, data, notebook=notebook, cmap=cmap,
-                                **kwargs)
-        except Exception as e:
-            print(e)
-            pg.error("fix pyvista bindings")
-
+                            **kwargs)
         if not hold:
             plotter.show()
         return plotter, None

--- a/pygimli/viewer/vistaview.py
+++ b/pygimli/viewer/vistaview.py
@@ -26,21 +26,8 @@ else:
 if panel is None:
     pg.warn("Please install panel to plot 3D models in Jupyter Notebooks - conda install panel")
 else:
-    pyvista.set_jupyter_backend('panel')
+    pyvista.set_jupyter_backend('panel')    
 
-#if pythreejs is None:
- #   pg.warn("Please install pythreejs")
-#else:
- #   pyvista.set_jupyter_backend('pythreejs')
-
-#if ipygany is None:
- #   pg.warn("Please install ipygany")
-#else:
- #   pyvista.set_jupyter_backend('ipygany')    
-# True for Jupyter notebooks and sphinx-builds
-#_backend = plt.get_backend().lower()
-#inline = "inline" in _backend or _backend == "agg"
-#jupyter_backend='ipygany'
 if PyQt5 is None:
     inline = True
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ sphinxcontrib-programoutput
 sphinxcontrib-doxylink
 sphinx-gallery
 bibtexparser
-pyvista==0.24.2
+pyvista==0.33
+panel
 
 # optional, but strongly recommended
 scipy


### PR DESCRIPTION
I've chosen the jupyter backend end `panel` because it doesn't depend on a server-based rendering location and it uses vtk.js as a backend. It also supports color bars which can be displayed by clicking on the lower left `...`.[ More info on using `panel` in PyVista :](https://docs.pyvista.org/user-guide/jupyter/panel.html) 

- Added `panel` to the requirements where pyvista was listed, including the docs. 
- Updated the pyvista version required to 0.24 -> 0.33 . 
- Updated the Refraction in 3D example on the website to see if it works when building the docs. 
- Added `notebook=True` to `test_show.py`

Please let me know if I need to add `panel` requirements to anything else. I'm not sure if I did enough to see it on the website. 
Cheers,
Andrea
