### PR TITLE
Add scooby-report as pg.Report()

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -19,6 +19,7 @@ panel
 
 # optional, but strongly recommended
 scipy
+scooby
 
 # useful
 ipython

--- a/pygimli/__init__.py
+++ b/pygimli/__init__.py
@@ -34,6 +34,7 @@ from .meshtools import createGrid, interpolate
 from .solver import solve
 from .utils import boxprint, cache, cut, unique, unit, cmap, randn
 from .utils import prettify as pf
+from .utils.utils import Report
 
 from .viewer import show, wait, noShow, hold
 

--- a/pygimli/utils/utils.py
+++ b/pygimli/utils/utils.py
@@ -10,6 +10,25 @@ import numpy as np
 
 import pygimli as pg
 
+# scooby is a soft dependency.
+try:
+    from scooby import Report as ScoobyReport
+except ImportError:
+    class ScoobyReport:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __repr__(self):
+            message = (
+                "`Report` requires `scooby`. Install it via `pip install scooby` "
+                "or `conda install -c conda-forge scooby`."
+            )
+            return message
+
+        def to_dict(self):
+            return {}
+
+
 class ProgressBar(object):
     """Animated text-based progressbar.
 
@@ -908,3 +927,36 @@ def filterLinesByCommentStr(lines, comment_str='#'):
     for j in comment_line_idx[::-1]:
         del lines[j]
     return lines
+
+
+class Report(ScoobyReport):
+    r"""Report date, time, system, and package version information.
+
+    Use ``scooby`` to report date, time, system, and package version
+    information in any environment, either as html-table or as plain text.
+
+    Parameters
+    ----------
+    additional : {package, str}, default: None
+        Package or list of packages to add to output information (must be
+        imported beforehand or provided as string).
+
+    """
+
+    def __init__(self, additional=None, **kwargs):
+        """Initiate a scooby.Report instance."""
+
+        # Mandatory packages.
+        core = ['pygimli', 'pgcore', 'numpy', 'matplotlib']
+
+        # Optional packages.
+        optional = ['scipy', 'tqdm', 'IPython', 'meshio', 'tetgen', 'pyvista']
+
+        inp = {
+            'additional': additional,
+            'core': core,
+            'optional': optional,
+            **kwargs  # User input overwrites defaults.
+        }
+
+        super().__init__(**inp)


### PR DESCRIPTION
## Scooby-report for pyGIMLi

### What is it about

This PR introduces `Report`:
```
import pygimli as pg
pg.Report()
```
which will print date, time, system, and package version information as a plain text table or as a html formatted table if the output supports it.

For this to work `scooby` needs to be installed. However, `scooby` is a soft dependency. If it is not installed `pg.Report()` will simply print that `scooby` is required for that feature, and shows the installation instructions.

### TODO

You need to tell me, or adjust yourself, two crucial points:
- **Mandatory packages**: These packages are always shown. I put currently
  `core = ['pygimli', 'pgcore', 'numpy', 'matplotlib']`
  but I am pretty sure that needs adjustments.
- **Optional packages**: These packages are only shown if installed. I put currently
  `optional = ['scipy', 'tqdm', 'IPython', 'meshio', 'tetgen', 'pyvista']`


### Examples

| Terminal  | Notebook |
| ------------- | ------------- |
| ![2022-10-05-01](https://user-images.githubusercontent.com/8020943/194237325-337cb589-234b-439c-8c63-6edb2b01c053.png) | ![2022-10-05-05](https://user-images.githubusercontent.com/8020943/194237315-7c5fc7b1-04c2-4e42-9a7e-f0b6b698f3ac.png)  |

**`scooby` not installed**
![2022-10-05-03](https://user-images.githubusercontent.com/8020943/194237320-003ee8af-5aad-4651-a2cf-7e94aac1adcd.png)


