### PR TITLE
Update documentation and scripts for manual compilation on Linux

### DIFF
--- a/core/scripts/Dockerfile_DebianBookworm
+++ b/core/scripts/Dockerfile_DebianBookworm
@@ -4,30 +4,29 @@
 # before proceeding, copy to an empty directory and rename to "Dockerfile"
 
 # build with:
-# docker build -t "gimli/gimli_0.1" .
+# docker build -t "gimli/master" .
 
 # after building, start an interactive console in the container with
-# docker run --rm -i -t -u gimli -v "${PWD}":/HOST -w /home/gimli "gimli/gimli_0.1" bash
+# docker run --rm -i -t -u gimli -v "${PWD}":/HOST -w /home/gimli "gimli/master" bash
 # note that this command will mount the present directory to /HOST in the
 # container, e.g., to copy the final build to the host computer
 
 # the start the build process with
-# bash build_pygimli_py3.5.sh
+# bash build_pygimli.sh
 
-FROM debian:stretch
+FROM debian:bookworm
 
 RUN apt-get update
 
 RUN apt-get install -y wget subversion git cmake mercurial
 RUN apt-get install -y libboost-all-dev libblas-dev liblapack-dev
-RUN apt-get install -y python python-setuptools
-RUN apt-get install -y python-numpy python-matplotlib
+RUN apt-get install -y libsuitesparse-dev
 RUN apt-get install -y libedit-dev clang llvm-dev python3-dev
-RUN apt-get install -y python3  python3-numpy python3-matplotlib
+RUN apt-get install -y python3 python3-numpy python3-matplotlib
 RUN apt-get install -y python3-setuptools
 
 # not required, but used for debugging and testing
-RUN apt-get install -y vim-nox python-pytest python3-pytest
+RUN apt-get install -y python3-pytest
 
 USER root
 # set the root password to "root"
@@ -41,12 +40,15 @@ RUN chown -R gimli:gimli /home/gimli
 USER gimli
 ENV HOME "/home/gimli"
 
-# COPY build_pygimli_py3.5.sh /home/gimli/build_pygimli_py3.5.sh
+# COPY build_pygimli.sh /home/gimli/build_pygimli.sh
+
+# Refer to https://www.pygimli.org/compilation.html#useful-cmake-settings
+# for additional cmake settings
 RUN echo '#!/bin/bash \n \
 git clone https://github.com/gimli-org/gimli.git \n \
 mkdir build \n \
 cd build \n \
-cmake ../gimli -DPYVERSION=3.5 \n \
+cmake ../gimli \n \
 make -j 2 gimli \n \
 make -j 2 apps \n \
-make -j 2 pygimli \n ' > /home/gimli/build_pygimli_py3.5.sh
+make -j 2 pygimli \n ' > /home/gimli/build_pygimli.sh

--- a/core/scripts/Dockerfile_DebianBookworm
+++ b/core/scripts/Dockerfile_DebianBookworm
@@ -1,5 +1,5 @@
 # Dockerfile used to create a build environment for PyGimli based on the
-# official Debian stretch base image
+# official Debian bookworm base image
 
 # before proceeding, copy to an empty directory and rename to "Dockerfile"
 

--- a/core/scripts/install/install_gimli.sh
+++ b/core/scripts/install/install_gimli.sh
@@ -50,6 +50,17 @@ function boxprint()
   tput sgr 0
 }
 
+function is_virtual_env()
+# Returns 0 if in virtual environment, 1 otherwise
+# See PEP 0668: https://peps.python.org/pep-0668/
+{
+    case "$(python -c "import sys; \\
+        print(sys.base_prefix != sys.prefix or hasattr(sys, 'real_prefix'))")" in
+        "True") return 0 ;;
+        *)      return 1 ;;
+    esac
+}
+
 boxprint "Geophysical Inversion and Modelling Library (www.gimli.org)"
 
 help(){
@@ -181,7 +192,13 @@ getGIMLI(){
 
         chmod +x $PYGIMLI_SOURCE_DIR/apps/*
 
-        pip3 install -r $PYGIMLI_SOURCE_DIR/dev_requirements.txt --user
+        if is_virtual_env; then
+            echo "Installing requirements into virtual enviroment"
+            pip3 install -r $PYGIMLI_SOURCE_DIR/dev_requirements.txt
+        else
+            echo "Installing requirements into user space"
+            pip3 install -r $PYGIMLI_SOURCE_DIR/dev_requirements.txt --user
+        fi
 
     popd
 }

--- a/doc/BUILD_LINUX.rst
+++ b/doc/BUILD_LINUX.rst
@@ -26,8 +26,10 @@ tab.
 If the installation fails you can try the following instructions for manual
 installation.
 
-Detailed Installation on Debian Stretch
+Detailed Installation on Debian
 .......................................
+
+Tested on Debian 12 (Bookworm).
 
 In order to build pygimli (and gimli) Python 3, install
 the required packages:
@@ -36,18 +38,16 @@ the required packages:
 
     sudo apt-get install wget subversion git cmake mercurial g++ \
         libboost-all-dev libblas-dev liblapack-dev libopenblas-dev \
-        libedit-dev python3-dev \
+        libsuitesparse-dev libedit-dev python3-dev \
         python3-numpy python3-matplotlib \
         python3-setuptools
 
-Create a directory for your installation, e.g., $HOME/src
+Create a directory for your installation, e.g., $HOME/src/gimli
 
 .. code-block:: bash
 
-    mkdir -p ~/src
-    cd src
-    mkdir -p gimli
-    cd gimli
+    mkdir -p ~/src/gimli
+    cd ~/src/gimli
 
 Checkout the current sources for libgimli:
 
@@ -111,9 +111,10 @@ example assumes that the **src** directory resides in your home directory):
 
 .. code-block:: bash
 
-    export PYTHONPATH=$PYTHONPATH:$HOME/src/gimli/gimli
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/src/gimli/build/lib
-    export PATH=$PATH:$HOME/src/gimli/build/bin
+    GIMLI_INSTALLATION=$HOME/src/gimli
+    export PYTHONPATH=$PYTHONPATH:$GIMLI_INSTALLATION/gimli
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GIMLI_INSTALLATION/build/lib
+    export PATH=$PATH:$GIMLI_INSTALLATION/build/bin
 
 If you want to use the C++ command line applications, call
 
@@ -149,12 +150,14 @@ then you can run the internal test suite with
 
     python -c "import pygimli; pygimli.test()"
 
-Using Docker to build in Debian stretch (for advanced users only!)
-..................................................................
+Using Docker to build in Debian Bookworm (for advanced users only!)
+...................................................................
 
 If you want to use a Docker container to build (and possibly use) pyGIMLi, you
-can use the Dockerfile found in the **scripts/** subdirectory named
-*Dockerfile_DebianStretch*. Please refer to the file for further instructions.
+can use the Dockerfile found in the
+`scripts/ <https://github.com/gimli-org/gimli/tree/master/core/scripts>`_
+subdirectory named *Dockerfile_DebianBookworm*. Please refer to the file for
+further instructions.
 
 Example Installation on Ubuntu
 ..............................
@@ -163,6 +166,7 @@ Example Installation on Ubuntu
 
     sudo apt-get install libc-dev subversion git cmake mercurial
     sudo apt-get install libboost-all-dev libblas-dev liblapack-dev libedit-dev
+    sudo apt-get install libsuitesparse-dev
     sudo apt-get install python3-dev python3-matplotlib python3-numpy
 
     mkdir -p ~/src/gimli
@@ -190,15 +194,6 @@ You can force cmake to select the correct version with:
 .. code-block:: bash
 
     cmake ../gimli -DBoost_PYTHON_LIBRARY=/usr/lib64/libboost_python3.so
-
-If the build misses libedit:
-
-.. code-block:: bash
-
-    /usr/bin/ld: cannot find -ledit
-
-Install *libedit*, e.g. 'apt-get install libedit' on Debian/Ubuntu.
-
 
 castXML
 .......


### PR DESCRIPTION
Hi! As pointed out in #552 this mainly fix three problems when compiling pygimli for Linux.

Linux compilation docs and installation scripts were modified. Here is a summary of the changes:

- The dependency `libsuitesparse-dev` is now mentioned where needed (added to the docs and the Dockerfile) (#551).
- Remove the `libdev` troubleshooting in the Linux compilation docs. I believe this was equivalent to `libedit-dev` for old Debian versions, since the `libdev` package doesn't exists anymore.
- All references to Debian 9 were changed to Debian 12 along with the necessary modifications.
- The https://github.com/gimli-org/gimli/blob/a4ce8424fbd075d81d9019b05a726dcfc6d004a1/core/scripts/install/install_gimli.sh installation script now first check if the user is within a virtual environment. If so, the `pip3 install` is not called with the `--user` flag anymore, since it's [not necessary for virtual environments](https://pip.pypa.io/en/stable/user_guide/#user-installs) and can [lead to errors](https://github.com/microsoft/vscode-python/issues/14327).
- The obsolete `Dockerfile_DebianStretch` has been rewritten to work on Debian Bookworm (tested locally and working).

Reviews and feedback are appreciated :)

Closes #552