### PR TITLE
fix #715, we can obtain the shape of a Cm05Matrix

### DIFF
--- a/pygimli/math/matrix.py
+++ b/pygimli/math/matrix.py
@@ -488,7 +488,7 @@ class Cm05Matrix(MatrixBase):
 
     def cols(self):
         """Return number of columns (using underlying matrix)."""
-        return self.row()
+        return self.rows()
 
     def mult(self, x):
         """Multiplication from right-hand side (dot product)."""


### PR DESCRIPTION
In this PR, I fix a minor issue that exists for obtaining the shape of a `Cm05Matrix`, issue #715  


Without this PR, running the following script 
```Python
import pygimli as pg

# No matter what mesh
A = pg.utils.covarianceMatrix(mesh, I=5)
cm05 = pg.matrix.createCm05(A)

print(cm05.shape)
```
throws 
```Python
return self.row()
           ^^^^^^^^
AttributeError: 'Cm05Matrix' object has no attribute 'row'
```

Accepting this PR, this error will be fixed

fix #715