### PR TITLE
Update ertIPManager.py

### DIFF
--- a/pygimli/physics/ert/ertIPManager.py
+++ b/pygimli/physics/ert/ertIPManager.py
@@ -92,6 +92,10 @@ class ERTIPManager(ERTManager):
         else:
             self.invertTDIP()
 
+    def invertDC(self, *args, **kwargs):
+        # Needed if we want to do ERT first without the IP and do IP later
+        super().invert(*args, **kwargs)
+    
     def simulate(self, mesh, res, m, scheme=None, **kwargs):
         """."""
         from pygimli.physics.ert import ERTModelling


### PR DESCRIPTION
In ERTIPManager I added the option to run a pure ERT inversion. I think this is useful to be able to make sure that the resistivity model is good before running the IP inversions. Before my change, this was not possible, because the invert() function in ERTIPManager was overwriting the invert() function in ERTManager, and there is no way of constructing an ERTIPManager object directly from an ERTManager object. Creating an invertDC function seemed to me the simplest solution...

Frist of all, **thank you** for submitting a pull request. We appreciate that
you follow the spirit of open-source and that you are willing to contribute to
pyGIMLi. Please make sure that this PR is targeted to the `dev` branch. If not,
please [change this
now](https://github.com/blog/2224-change-the-base-branch-of-a-pull-request).
Additional notes on development can be found on
[pygimli.org/dev](https://www.pygimli.org/dev).
