### PR TITLE
Fixing the iteration number again (I think)

### DIFF
--- a/pygimli/frameworks/inversion.py
+++ b/pygimli/frameworks/inversion.py
@@ -700,7 +700,7 @@ class Inversion(object):
 
         for i in range(1, maxIter+1):
             if self._preStep and callable(self._preStep):
-                self._preStep(i + 1, self)
+                self._preStep(i, self)
 
             if self.verbose:
                 print("-" * 80)
@@ -730,7 +730,7 @@ class Inversion(object):
                 self.showProgress(showProgress)
 
             if self._postStep and callable(self._postStep):
-                self._postStep(i + 1, self)
+                self._postStep(i, self)
 
             if self.robustData:
                 self.inv.robustWeighting()


### PR DESCRIPTION
In here, I fixed the iteration number: https://github.com/gimli-org/gimli/pull/643

In here, https://github.com/gimli-org/gimli/commit/d72b8287aeda08dca20bea1fc680c3493f74f01d, the iterator was changed from `range(maxIter)` to `range(1, maxIter+1)`, without changing back PR643, making the thing wrong again.