### PR TITLE
Update the Dockerfile that can be used to build Pygimli in a Debian bookworm Docker container

### DIFF
--- a/core/scripts/Dockerfile_DebianBookworm
+++ b/core/scripts/Dockerfile_DebianBookworm
@@ -1,19 +1,27 @@
 # Dockerfile used to create a build environment for PyGimli based on the
 # official Debian bookworm base image
 
-# before proceeding, copy to an empty directory and rename to "Dockerfile"
+# before proceeding, do the following:
+#  * create an empty directory
+#  * copy this file AND the build script, build_pygimli.sh, into this directory
+#    and rename to "Dockerfile"
+#  * run a 'chmod -R 0777 .' in the new directory. This is required so that the
+#  container can copy the build results into this directory later
 
-# build with:
-# docker build -t "gimli/master" .
+# Then, build the docker image by calling:
+#    docker build -t "pg_build" .
 
-# after building, start an interactive console in the container with
-# docker run --rm -i -t -u gimli -v "${PWD}":/HOST -w /home/gimli "gimli/master" bash
-# note that this command will mount the present directory to /HOST in the
+# Afterwards, you can trigger the build in the container with:
+#    docker run --rm -i -t -u gimli -v "${PWD}":/HOST -w /home/gimli "pg_build" /home/gimli/build_pygimli.sh
+
+# Alternatively, you can spawn a shell in the container and build/modify manually:
+
+#    docker run --rm -i -t -u gimli -v "${PWD}":/HOST -w /home/gimli "gimli/master" bash
+
+# The build script can be found in /home/gimli/build_pygimli.sh
+
+# Note that this command will mount the present directory to /HOST in the
 # container, e.g., to copy the final build to the host computer
-
-# the start the build process with
-# bash build_pygimli.sh
-
 FROM debian:bookworm
 
 RUN apt-get update
@@ -23,10 +31,14 @@ RUN apt-get install -y libboost-all-dev libblas-dev liblapack-dev
 RUN apt-get install -y libsuitesparse-dev
 RUN apt-get install -y libedit-dev clang llvm-dev python3-dev
 RUN apt-get install -y python3 python3-numpy python3-matplotlib
-RUN apt-get install -y python3-setuptools
+RUN apt-get install -y python3-setuptools python3-venv
+RUN apt-get install -y libopenblas-dev
+RUN apt-get install -y tetgen
+# required for building a Debian package
+RUN apt-get install -y python3-stdeb dh-python
 
 # not required, but used for debugging and testing
-RUN apt-get install -y python3-pytest
+RUN apt-get install -y python3-pytest python3-pip
 
 USER root
 # set the root password to "root"
@@ -41,14 +53,4 @@ USER gimli
 ENV HOME "/home/gimli"
 
 # COPY build_pygimli.sh /home/gimli/build_pygimli.sh
-
-# Refer to https://www.pygimli.org/compilation.html#useful-cmake-settings
-# for additional cmake settings
-RUN echo '#!/bin/bash \n \
-git clone https://github.com/gimli-org/gimli.git \n \
-mkdir build \n \
-cd build \n \
-cmake ../gimli \n \
-make -j 2 gimli \n \
-make -j 2 apps \n \
-make -j 2 pygimli \n ' > /home/gimli/build_pygimli.sh
+COPY build_pygimli.sh /home/gimli/build_pygimli.sh

--- a/core/scripts/build_pygimli.sh
+++ b/core/scripts/build_pygimli.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+# This script checks out pygimli from git and builds it. Afterwards, Python
+# source and binary dist tar.gz files are created, as well as a .whl and a .deb
+# file
+
+# Refer to https://www.pygimli.org/compilation.html#useful-cmake-settings
+# for additional cmake settings
+
+git clone https://github.com/gimli-org/gimli.git
+
+mkdir build
+cd build
+cmake ../gimli
+make -j 2 gimli
+make -j 2 apps
+make -j 2 pygimli
+
+cd ../gimli
+# source and binary tar.gz files
+python3 setup.py sdist
+python3 setup.py bdist
+# build a wheel that can be installed using pip
+pip wheel .
+
+outdir="/HOST/pg_artifacts"
+test -d "${outdir}" || mkdir "${outdir}"
+cp -r dist "${outdir}/"
+cp *.whl "${outdir}"
+
+# build a quick and dirty .deb file
+export PYBUILD_DISABLE=test
+python3 setup.py --command-packages=stdeb.command bdist_deb
+cp -r deb_dist "${outdir}/"
+
+# make sure we can read/write/delete the output data on the host
+chmod -R 0777 "${outdir}"


### PR DESCRIPTION
The scripts now build a .whl (wheel) file that can be installed directly using pip, as well as source distributions and a Debian .deb file.