### PR TITLE
docs: add reproducibility tips for beginners

### DIFF
--- a/doc/doc/repro_tips_beginner.rst
+++ b/doc/doc/repro_tips_beginner.rst
@@ -1,0 +1,15 @@
+Reproducibility tips (for beginners)
+====================================
+
+• Use a pinned environment (conda):
+  conda create -n pg -c gimli -c conda-forge pygimli
+  conda activate pg
+
+• Set random seeds in examples to stabilize results:
+  import numpy as np; np.random.seed(0)
+
+• Note OS differences (Windows vs. Linux/Mac) when paths or installers differ.
+
+• Link to install & contributing guides for more detail.
+
+References: Installation, Contributing.


### PR DESCRIPTION
Tiny docs addition: beginner-friendly “Reproducibility tips” box.

- Added new short page with environment + seed tips.
- Helps new users reproduce tutorial outputs.
- Can be merged or relocated into a specific tutorial page if you prefer.
